### PR TITLE
Allow setConfiguration to return correctly

### DIFF
--- a/LoRa_E220.cpp
+++ b/LoRa_E220.cpp
@@ -435,8 +435,6 @@ Status LoRa_E220::sendStruct(void *structureManaged, uint16_t size_) {
 
 		result = this->waitCompleteResponse(5000, 5000);
 		if (result != E220_SUCCESS) return result;
-		DEBUG_PRINT(F("Clear buffer..."))
-		this->cleanUARTBuffer();
 
 		DEBUG_PRINTLN(F("ok!"))
 
@@ -641,6 +639,9 @@ ResponseStatus LoRa_E220::setConfiguration(Configuration configuration, PROGRAM_
 	if (RETURNED_COMMAND != ((Configuration *)&configuration)->COMMAND || REG_ADDRESS_CFG!= ((Configuration *)&configuration)->STARTING_ADDRESS || PL_CONFIGURATION!= ((Configuration *)&configuration)->LENGHT){
 		rc.code = ERR_E220_HEAD_NOT_RECOGNIZED;
 	}
+
+	DEBUG_PRINT(F("Clear buffer..."))
+	this->cleanUARTBuffer();
 
 	return rc;
 }


### PR DESCRIPTION
According to the datasheet the set configuration command returns values that are currently removed by the clearing of the buffer. This means that the checks performed after sending the configuration fail, resulting in the function retuning a failure code. In order to allow the setConfiguration command to return correctly the clearing of the buffer is moved from the sendStruct command to after the returned data has been examined. This feels more like the correct place for this to be done as it removes any old data from the buffer following a change of configuration.